### PR TITLE
Introduce learning engine

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,95 @@
+{
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "0625932976b3ae23949f6b816d13bd97f3b40b7c",
+        "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
+        "version" : "0.14.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "f9acfa1a45f4483fe0f2c434a74e6f68f865d12d",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "79307e939fd5a99304f44bae4cf42cdc430f9480",
+        "version" : "0.53.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "505aa98716275fbd045d8f934fee3337c82ffbd3",
+        "version" : "0.10.3"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "25c9b6789b4b7ada649a3808e6d8de1489082a33",
+        "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "f52eee28bdc6065aa2f8424067e6f04c74bda6e6",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "state" : {
+        "revision" : "47dd574b900ba5ba679f56ea00d4d282fc7305a6",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "4af50b38daf0037cfbab15514a241224c3f62f98",
+        "version" : "0.8.5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,25 @@ import PackageDescription
 let package = Package(
   name: "doctrina-core",
   platforms: [
-    .macOS(.v10_15), .iOS(.v15),
+    .macOS(.v10_15),
+    .iOS(.v15),
   ],
-  products: [],
-  dependencies: [],
-  targets: []
+  products: [
+    .library(name: "Core", targets: ["Core"])
+  ],
+  dependencies: [
+    .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.53.0"),
+  ],
+  targets: [
+    .target(
+      name: "Core",
+      dependencies: [
+        .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+      ]
+    ),
+    .testTarget(
+      name: "CoreTests",
+      dependencies: [ "Core" ]
+    ),
+  ]
 )

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # doctrina-core
-Simple and powerful framework for building learning and education applications focusing on memorising new things.
+Simple and powerful framework for building learning and education applications
+focusing on memorising new things.
+
+doctrina-core written on Swift and is based on Composable Architecture.
+It can be used to build iOS and Mac applications as well as websites.

--- a/Sources/Core/Activity.swift
+++ b/Sources/Core/Activity.swift
@@ -1,0 +1,46 @@
+import ComposableArchitecture
+
+/// Create Activity by implementing inner reducers and pass it to |init|
+/// and it will call use reducers according to activity lyfecycle.
+public struct Activity<
+  CheckActivity: ReducerProtocol,
+  OtherActivity: ReducerProtocol,
+  CheckCoreAction
+>: ReducerProtocol where
+CheckActivity.Action == CheckActivityAction<CheckCoreAction>,
+CheckActivity.State: CheckActivityState {
+  public enum State {
+    case check(CheckActivity.State)
+    case other(OtherActivity.State)
+  }
+
+  public enum Action {
+    case check(CheckActivity.Action)
+    case other(OtherActivity.Action)
+  }
+
+  public var checkActivity: CheckActivity
+  public var otherActivity: OtherActivity
+
+  public init(
+    checkActivity: CheckActivity,
+    otherActivity: OtherActivity
+  ) {
+    self.checkActivity = checkActivity
+    self.otherActivity = otherActivity
+  }
+
+  public var body: some ReducerProtocol<State, Action> {
+    EmptyReducer()
+      .ifCaseLet(/State.check, action: /Action.check) { checkActivity }
+      .ifCaseLet(/State.other, action: /Action.other) { otherActivity }
+  }
+}
+
+extension Activity.State: Equatable
+where CheckActivity.State: Equatable,
+      OtherActivity.State: Equatable {}
+
+extension Activity.Action: Equatable
+where CheckActivity.Action: Equatable,
+      OtherActivity.Action: Equatable {}

--- a/Sources/Core/ActivityResult.swift
+++ b/Sources/Core/ActivityResult.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Status of completed activity is binary by now.
+///
+/// In the future we should extend it to contain intermediate states.
+/// Consider the following example:
+/// User was asked to combine the sentence using words. The answer given almost matches
+/// the required sentence, but contains some small mistake. Should we mark the result as
+/// wrong or should we mark it as correct with minor inaccuracy?
+public enum ActivityResultStatus {
+  case correct
+  case wrong
+}
+
+/// An activity result represents the status of completed activity.
+/// It can be stored persistantly to collect information about user's progress in studying.
+///
+/// init is available only from internals.
+/// Consumers should not instanciate ActivityResult theirselfs.
+public struct ActivityResult<ActivityType> {
+  /// Type of activity user completed.
+  /// |ActivityType| is intended to be an enum covering all possible activites in the application.
+  public var activityType: ActivityType
+
+  /// Date when the activity was completed.
+  public var date: Date
+
+  /// Status of completed activity.
+  public var status: ActivityResultStatus
+
+  public init(activityType: ActivityType, date: Date, status: ActivityResultStatus) {
+    self.activityType = activityType
+    self.date = date
+    self.status = status
+  }
+}
+
+extension ActivityResult: Equatable where ActivityType: Equatable {}

--- a/Sources/Core/CheckActivityAction.swift
+++ b/Sources/Core/CheckActivityAction.swift
@@ -1,0 +1,30 @@
+/// Use this enum as |Action| implementation for checking activities.
+///
+/// |CoreAction| is user defined action set used to express custom activity flow.
+public enum CheckActivityAction<CoreAction> {
+  /// Use DelegateAction to communicate with learning Engine.
+  public enum DelegateAction {
+    case storeResult(ActivityResultStatus)
+    case activityWasCompleted
+  }
+  
+  case delegate(DelegateAction)
+
+  // Custom logic of activity is declared here.
+  case core(CoreAction)
+
+  /// Sent by learning logic and expects to recieve delegate action back.
+  case checkAnswer
+}
+
+/// Each checking activity state should conform to this protocol.
+///
+/// In future we should get rid of |ActivityType| and determine type of activity the other way.
+public protocol CheckActivityState {
+  associatedtype ActivityType
+
+  var activityType: ActivityType { get }
+}
+
+extension CheckActivityAction.DelegateAction: Equatable {}
+extension CheckActivityAction: Equatable where CoreAction: Equatable {}

--- a/Sources/Core/Engine.swift
+++ b/Sources/Core/Engine.swift
@@ -1,0 +1,89 @@
+import ComposableArchitecture
+
+/// Engine of learning process. Manages activities, stores statistics and more.
+public struct Engine<
+  CheckActivity: ReducerProtocol,
+  OtherActivity: ReducerProtocol,
+  CheckCoreAction
+>: ReducerProtocol where
+CheckActivity.State: CheckActivityState,
+CheckActivity.Action == CheckActivityAction<CheckCoreAction> {
+  public typealias ResolvedActivity = Activity<
+    CheckActivity, OtherActivity, CheckCoreAction
+  >
+
+  /// Implement this closure to provide continuous flow of activies.
+  ///
+  /// Note: For correct animations consider changing activity type each type closure is called.
+  public typealias NextActivity = () -> ResolvedActivity.State
+
+  public struct State {
+    public var stats: [ActivityResult<CheckActivity.State.ActivityType>]
+    public var activity: ResolvedActivity.State
+
+    public init(
+      stats: [ActivityResult<CheckActivity.State.ActivityType>],
+      activity: ResolvedActivity.State
+    ) {
+      self.stats = stats
+      self.activity = activity
+    }
+  }
+
+  public typealias Action = ResolvedActivity.Action
+
+  public var activity: ResolvedActivity
+  public var nextActivity: NextActivity
+
+  @Dependency(\.date) var now
+
+  public init(
+    activity: ResolvedActivity,
+    nextActivity: @escaping NextActivity
+  ) {
+    self.activity = activity
+    self.nextActivity = nextActivity
+  }
+
+  public var body: some ReducerProtocol<State, Action> {
+    Reduce { [nextActivity, now] state, action in
+      switch action {
+      case let .check(action):
+        switch action {
+        case let .delegate(action):
+          switch action {
+          case let .storeResult(status):
+            guard case let .check(activity) = state.activity else {
+              // TODO: Add asserts on invalid state.
+              return .none
+            }
+            let result = ActivityResult(
+              activityType: activity.activityType,
+              date: now(),
+              status: status
+            )
+            state.stats.append(result)
+            return .none
+
+          case .activityWasCompleted:
+            state.activity = nextActivity()
+            return .none
+          }
+
+        default:
+          return .none
+        }
+
+      case .other:
+        // Other activity actions are managed by library's clients and are ignored by engine.
+        return .none
+      }
+    }
+    Scope(state: \.activity, action: /Action.self, child: { activity })
+  }
+}
+
+extension Engine.State: Equatable
+where CheckActivity.State: Equatable,
+      CheckActivity.State.ActivityType: Equatable,
+      OtherActivity.State: Equatable {}

--- a/Tests/CoreTests/EngineTests.swift
+++ b/Tests/CoreTests/EngineTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+import ComposableArchitecture
+
+import Core
+
+@MainActor
+final class EngineTests: XCTestCase {
+  func testAppendsStats() async {
+    let now = Date()
+
+    let store = TestStore(
+      initialState: Engine.State(
+        stats: [],
+        activity: .check(TestActivity.State.one)
+      ),
+      reducer: Engine(
+        activity: Activity(
+          checkActivity: TestActivity(),
+          otherActivity: EmptyReducer<Never, Never>()
+        ),
+        nextActivity: { .check(.two) }
+      )
+    ) {
+      $0.date = DateGenerator { now }
+    }
+
+    await store.send(.check(.checkAnswer))
+
+    let result = ActivityResult<TestActivityType>(
+      activityType: .one,
+      date: now,
+      status: .correct
+    )
+    await store.receive(.check(.delegate(.storeResult(.correct)))) {
+      $0.stats.append(result)
+    }
+
+    await store.receive(.check(.delegate(.activityWasCompleted))) {
+      $0.activity = .check(.two)
+    }
+  }
+}
+
+private struct TestActivity: ReducerProtocol {
+  enum State: Equatable, CheckActivityState {
+    case one
+    case two
+
+    var activityType: TestActivityType {
+      switch self {
+      case .one: return .one
+      case .two: return .two
+      }
+    }
+  }
+
+  enum CoreAction: Equatable {}
+
+  typealias Action = CheckActivityAction<CoreAction>
+
+  var body: some ReducerProtocol<State, Action> {
+    Reduce { state, action in
+      switch action {
+      case .checkAnswer:
+        return .merge(
+          .task { .delegate(.storeResult(.correct)) },
+          .task { .delegate(.activityWasCompleted) }
+        )
+
+      case .core:
+        return .none
+
+      case .delegate:
+        return .none
+      }
+    }
+  }
+}
+
+private enum TestActivityType: Equatable {
+  case one
+  case two
+}


### PR DESCRIPTION
### #2: Setup basic entries: Engine and Activity.
This PR introduce Engine and CheckActivity to the project.
The main goal of Engine is to provide continuous activities flow. Activities are divided into two categories:
1) Checking activity. Should check user's knowledge.
2) Other activity. Can do almost anything: suggest new learning items, show some statistics or change preferences.

PR includes tests on new features.
![photo_2023-05-16 12 28 05](https://github.com/LinbaTeam/doctrina-core/assets/6917667/ddaef4af-9a40-47e4-a10e-2f8174983f2e)
![photo_2023-05-16 12 28 04](https://github.com/LinbaTeam/doctrina-core/assets/6917667/d72e0631-7b48-42ef-ba14-57939b9d6787)
