### PR TITLE
Allow any hashable parameter values for analytics

### DIFF
--- a/Sources/Core/Analytics.swift
+++ b/Sources/Core/Analytics.swift
@@ -23,14 +23,14 @@ public struct Analytics {
     public var name: String
 
     /// Optional parameters with some additional information.
-    public var parameters: [String: String]?
+    public var parameters: [String: AnyHashable]?
 
     /// - Parameters
     ///  - name: unique event name
     ///  - parameters: optional parameters with some additional information.
     public init(
       name: String,
-      parameters: [String: String]? = nil
+      parameters: [String: AnyHashable]? = nil
     ) {
       self.name = name
       self.parameters = parameters


### PR DESCRIPTION
#7. Consider the following example:
```swift
analytics.track(Event(name: "event", parameters: ["count": String(count)]))
```
It would be nice to pass non-string parameters directly. This PR makes it possible to pass any hashable parameter to analytics:
```swift
analytics.track(Event(name: "event", parameters: ["count": count]))
```