### PR TITLE
Add activity type to analytics events

### DIFF
--- a/Sources/Core/Engine.swift
+++ b/Sources/Core/Engine.swift
@@ -82,7 +82,9 @@ Activity.Action == ActivityContainerAction<ActivityType, Item.ID, CoreAction> {
 
         case let .activityWasCompleted(eventParameters):
           state.activity = nextActivity(state.itemsWithStats, &state.core)
-          return .run { [analytics] _ in
+          var eventParameters = eventParameters
+          eventParameters["type"] = String(describing: activityType)
+          return .run { [analytics, eventParameters] _ in
             analytics(
               Analytics.Event(
                 name: "ACTIVITY_COMPLETED",

--- a/Tests/CoreTests/EngineTests.swift
+++ b/Tests/CoreTests/EngineTests.swift
@@ -51,7 +51,12 @@ final class EngineTests: XCTestCase {
       $0.activity = .two
     }
 
-    XCTAssertEqual(anylticsEvents, [.init(name: "ACTIVITY_COMPLETED", parameters: [:])])
+    XCTAssertEqual(anylticsEvents, [
+      .init(
+        name: "ACTIVITY_COMPLETED",
+        parameters: ["type": "one"]
+      ),
+    ])
   }
 }
 


### PR DESCRIPTION
Now activity type is automatically includes in analytics events when the activity is completed.